### PR TITLE
Add support for setting correct CPU max freq

### DIFF
--- a/drivers/cpufreq/qcom-cpufreq.c
+++ b/drivers/cpufreq/qcom-cpufreq.c
@@ -31,42 +31,6 @@
 
 static DEFINE_MUTEX(l2bw_lock);
 
-
-static unsigned long arg_cpu_max_c1 = 1593600;
-
-static int __init cpufreq_read_cpu_max_c1(char *cpu_max_c1)
-{
-	unsigned long ui_khz;
-	int ret;
-
-	ret = kstrtoul(cpu_max_c1, 0, &ui_khz);
-	if (ret)
-		return -EINVAL;
-
-	arg_cpu_max_c1 = ui_khz;
-	printk("cpu_max_c1=%lu\n", arg_cpu_max_c1);
-	return ret;
-}
-__setup("cpu_max_c1=", cpufreq_read_cpu_max_c1);
-
-static unsigned long arg_cpu_max_c2 = 2150400;
-
-static int __init cpufreq_read_cpu_max_c2(char *cpu_max_c2)
-{
-	unsigned long ui_khz;
-	int ret;
-
-	ret = kstrtoul(cpu_max_c2, 0, &ui_khz);
-	if (ret)
-		return -EINVAL;
-
-	arg_cpu_max_c2 = ui_khz;
-	printk("cpu_max_c2=%lu\n", arg_cpu_max_c2);
-	return ret;
-}
-__setup("cpu_max_c2=", cpufreq_read_cpu_max_c2);
-
-
 static struct clk *cpu_clk[NR_CPUS];
 static struct clk *l2_clk;
 static DEFINE_PER_CPU(struct cpufreq_frequency_table *, freq_table);
@@ -403,13 +367,6 @@ static struct cpufreq_frequency_table *cpufreq_parse_dt(struct device *dev,
 		 */
 		if (i > 0 && f <= ftbl[i-1].frequency)
 			break;
-
-		//Custom max freq
-		if ((cpu < 2 && f > arg_cpu_max_c1) ||
-				(cpu >= 2 && f > arg_cpu_max_c2)) {
-			nf = i;
-			break;
-		}
 
 		ftbl[i].driver_data = i;
 		ftbl[i].frequency = f;

--- a/drivers/cpufreq/qcom-cpufreq.c
+++ b/drivers/cpufreq/qcom-cpufreq.c
@@ -28,6 +28,7 @@
 #include <linux/platform_device.h>
 #include <linux/of.h>
 #include <trace/events/power.h>
+#include <soc/qcom/socinfo.h>
 
 static DEFINE_MUTEX(l2bw_lock);
 
@@ -35,7 +36,8 @@ static DEFINE_MUTEX(l2bw_lock);
 #define CONFIG_CPU_FREQ_MIN_CLUSTER1	307200
 #define CONFIG_CPU_FREQ_MAX_CLUSTER1	1593600
 #define CONFIG_CPU_FREQ_MIN_CLUSTER2	307200
-#define CONFIG_CPU_FREQ_MAX_CLUSTER2	2342400
+#define CONFIG_CPU_FREQ_MAX_CLUSTER2	2150400
+#define CONFIG_CPU_FREQ_MAX_CLUSTER2PRO	2342400
 
 static struct clk *cpu_clk[NR_CPUS];
 static struct clk *l2_clk;
@@ -161,7 +163,10 @@ static int msm_cpufreq_init(struct cpufreq_policy *policy)
 		if (policy->cpu >= 2)
 		{
 			policy->cpuinfo.min_freq = CONFIG_CPU_FREQ_MIN_CLUSTER2;
-			policy->cpuinfo.max_freq = CONFIG_CPU_FREQ_MAX_CLUSTER2;
+			if (socinfo_get_id() == 305)
+				policy->cpuinfo.max_freq = CONFIG_CPU_FREQ_MAX_CLUSTER2PRO;
+			else
+				policy->cpuinfo.max_freq = CONFIG_CPU_FREQ_MAX_CLUSTER2;
 		}
 
 		pr_err("cpufreq: failed to get policy min/max\n");
@@ -177,7 +182,10 @@ static int msm_cpufreq_init(struct cpufreq_policy *policy)
 	if (policy->cpu >= 2)
 	{
 		policy->min = CONFIG_CPU_FREQ_MIN_CLUSTER2;
-		policy->max = CONFIG_CPU_FREQ_MAX_CLUSTER2;
+		if (socinfo_get_id() == 305)
+			policy->max = CONFIG_CPU_FREQ_MAX_CLUSTER2PRO;
+		else
+			policy->max = CONFIG_CPU_FREQ_MAX_CLUSTER2;
 	}
 
 	cur_freq = clk_get_rate(cpu_clk[policy->cpu])/1000;

--- a/drivers/cpufreq/qcom-cpufreq.c
+++ b/drivers/cpufreq/qcom-cpufreq.c
@@ -31,6 +31,12 @@
 
 static DEFINE_MUTEX(l2bw_lock);
 
+// AP: Default startup frequencies
+#define CONFIG_CPU_FREQ_MIN_CLUSTER1	307200
+#define CONFIG_CPU_FREQ_MAX_CLUSTER1	1593600
+#define CONFIG_CPU_FREQ_MIN_CLUSTER2	307200
+#define CONFIG_CPU_FREQ_MAX_CLUSTER2	2342400
+
 static struct clk *cpu_clk[NR_CPUS];
 static struct clk *l2_clk;
 static DEFINE_PER_CPU(struct cpufreq_frequency_table *, freq_table);
@@ -144,7 +150,35 @@ static int msm_cpufreq_init(struct cpufreq_policy *policy)
 			cpumask_set_cpu(cpu, policy->cpus);
 
 	if (cpufreq_frequency_table_cpuinfo(policy, table))
+	{
+		// AP: set default frequencies to prevent overclocking or underclocking during start
+		if (policy->cpu <= 1)
+		{
+			policy->cpuinfo.min_freq = CONFIG_CPU_FREQ_MIN_CLUSTER1;
+			policy->cpuinfo.max_freq = CONFIG_CPU_FREQ_MAX_CLUSTER1;
+		}
+
+		if (policy->cpu >= 2)
+		{
+			policy->cpuinfo.min_freq = CONFIG_CPU_FREQ_MIN_CLUSTER2;
+			policy->cpuinfo.max_freq = CONFIG_CPU_FREQ_MAX_CLUSTER2;
+		}
+
 		pr_err("cpufreq: failed to get policy min/max\n");
+	}
+
+	// AP: set default frequencies to prevent overclocking or underclocking during start
+	if (policy->cpu <= 1)
+	{
+		policy->min = CONFIG_CPU_FREQ_MIN_CLUSTER1;
+		policy->max = CONFIG_CPU_FREQ_MAX_CLUSTER1;
+	}
+
+	if (policy->cpu >= 2)
+	{
+		policy->min = CONFIG_CPU_FREQ_MIN_CLUSTER2;
+		policy->max = CONFIG_CPU_FREQ_MAX_CLUSTER2;
+	}
 
 	cur_freq = clk_get_rate(cpu_clk[policy->cpu])/1000;
 


### PR DESCRIPTION
OnePlus 3T has Snapdragon 821 and max freq of big cores are 2.35 GHz.
This PR removes wrong max freq limits and adds support for different startup freqs for both OnePlus 3 and OnePlus 3T.
Tested on OnePlus 3T A3010.
Please test on OnePlus 3.